### PR TITLE
feat: Update the output json of the API scanning

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -16,3 +16,5 @@ openAPISpec: <urlOrPath> # Either filepath or URL
 
 exporter:
   jsonReportFilePath: report.json
+
+scanName: default-openapi-spec-scan  

--- a/internal/apispec/oas.go
+++ b/internal/apispec/oas.go
@@ -5,7 +5,7 @@ package apispec
 
 import (
 	"github.com/pb33f/libopenapi"
-	"github.com/pb33f/libopenapi/datamodel/high/v3"
+	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
 )
 
 func BuildOASV3Model(specBytes []byte) (*libopenapi.DocumentModel[v3.Document], error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/spf13/viper"
 	"go.uber.org/zap"
@@ -36,6 +37,7 @@ type Configuration struct {
 	Environment Environment `json:"environment"`
 	OpenAPISpec string      `json:"openAPISpec"`
 	Exporter    Exporter    `json:"exporter,omitempty"`
+	ScanName    string      `json:"scanName"`
 }
 
 func (c *Configuration) validate() error {
@@ -57,10 +59,6 @@ func (c *Configuration) validate() error {
 
 	if c.OpenAPISpec == "" {
 		return fmt.Errorf("configuration does not contain a valid OpenAPI Specification filepath or URL")
-	}
-
-	if c.Environment.ClusterId == 0 {
-		return fmt.Errorf("please provide a valid cluster ID")
 	}
 
 	if c.Exporter.JsonReportFilePath == "" {
@@ -88,6 +86,11 @@ func New(configFilePath string, logger *zap.SugaredLogger) (Configuration, error
 	if config.Exporter.JsonReportFilePath == "" {
 		config.Exporter.JsonReportFilePath = defaultJSONReportFilePath
 		logger.Warn("using default JSON report file path: ", defaultJSONReportFilePath)
+	}
+
+	if config.ScanName == "" {
+		config.ScanName = fmt.Sprintf("openapi-scan-%s", time.Now().Format("20060102-150405"))
+		logger.Infof("scanName not provided, using generated name: %s", config.ScanName)
 	}
 
 	if err := config.validate(); err != nil {

--- a/internal/core/core.go
+++ b/internal/core/core.go
@@ -68,7 +68,7 @@ func Run(ctx context.Context, configFilePath string) {
 
 	shadowApis, zombieApis := mgr.findShadowAndZombieApi(trie, events, model)
 	orphanApis := mgr.findOrphanApi(events, model)
-	if err := mgr.exportJsonReport(mgr.Cfg.Exporter.JsonReportFilePath, shadowApis, zombieApis, orphanApis, model.Model.Info, model.Index.GetConfig().SpecInfo.Version); err != nil {
+	if err := mgr.exportJsonReport(mgr.Cfg.Exporter.JsonReportFilePath, shadowApis, zombieApis, orphanApis); err != nil {
 		mgr.Logger.Error(err)
 		return
 	}

--- a/internal/core/discovery.go
+++ b/internal/core/discovery.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/emirpasic/gods/sets/hashset"
 	"github.com/pb33f/libopenapi"
-	"github.com/pb33f/libopenapi/datamodel/high/v3"
+	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
 
 	"github.com/5gsec/api-speculator/internal/apievent"
 	"github.com/5gsec/api-speculator/internal/apispec"

--- a/internal/core/reporter.go
+++ b/internal/core/reporter.go
@@ -6,8 +6,6 @@ package core
 import (
 	"encoding/json"
 	"os"
-
-	"github.com/pb33f/libopenapi/datamodel/high/base"
 )
 
 type API struct {
@@ -19,26 +17,20 @@ type API struct {
 }
 
 type apiReport struct {
-	ClusterId   int    `json:"clusterId"`
-	TenantId    int    `json:"tenantId"`
-	SpecTitle   string `json:"specTitle"`
-	SpecVersion string `json:"specVersion"`
-	OASVersion  string `json:"oasVersion"`
-	ShadowAPIs  []API  `json:"shadowApis,omitempty"`
-	ZombieAPIs  []API  `json:"zombieApis,omitempty"`
-	OrphanAPIs  []API  `json:"orphanApis,omitempty"`
+	TenantId   int    `json:"tenantId"`
+	ScanName   string `json:"scan_name"`
+	ShadowAPIs []API  `json:"shadowApis,omitempty"`
+	ZombieAPIs []API  `json:"zombieApis,omitempty"`
+	OrphanAPIs []API  `json:"orphanApis,omitempty"`
 }
 
-func (m *Manager) exportJsonReport(reportFilePath string, shadowApis, zombieApis, orphanApis []API, specInfo *base.Info, openApiVersion string) error {
+func (m *Manager) exportJsonReport(reportFilePath string, shadowApis, zombieApis, orphanApis []API) error {
 	report := apiReport{
-		ClusterId:   m.Cfg.Environment.ClusterId,
-		TenantId:    m.Cfg.Environment.TenantId,
-		SpecTitle:   specInfo.Title,
-		SpecVersion: specInfo.Version,
-		OASVersion:  openApiVersion,
-		ShadowAPIs:  shadowApis,
-		ZombieAPIs:  zombieApis,
-		OrphanAPIs:  orphanApis,
+		TenantId:   m.Cfg.Environment.TenantId,
+		ScanName:   m.Cfg.ScanName,
+		ShadowAPIs: shadowApis,
+		ZombieAPIs: zombieApis,
+		OrphanAPIs: orphanApis,
 	}
 
 	f, err := os.OpenFile(reportFilePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o666)


### PR DESCRIPTION
feat([CNAPP-20699](https://accu-knox.atlassian.net/browse/CNAPP-20699)): support scanName and make clusterId optional

- Added `scanName` to configuration with support for default value.
  - If not provided in config, it auto-generates a name (e.g., openapi-scan-20250722-103045).
- Made `clusterId` optional .
  - When `clusterId` is not set or is 0, documents are fetched for all clusters.

**JSON OUTPUT-**
[report.json](https://github.com/user-attachments/files/21372740/report.json)

```
{
 "tenantId": 11,
 "scan_name": "default-openapi-spec-scan",
 "shadowApis": [
  {
   "clusterName": "api-security-test5",
   "serviceName": "catalogue",
   "requestMethod": "GET",
   "requestPath": "/catalogue",
   "occurrences": 1
  },
  {
   "clusterName": "Test-Api-Security",
   "serviceName": "archive.ubuntu.com",
   "requestMethod": "GET",
   "requestPath": "/ubuntu/dists/noble-backports/universe/binary-amd64/by-hash/SHA256/{param1}",
   "occurrences": 1
  },
  {
   "clusterName": "api-security-test5",
   "serviceName": "catalogue",
   "requestMethod": "GET",
   "requestPath": "/catalogue",
   "occurrences": 1
  },
  {
   "clusterName": "api-security-test5",
   "serviceName": "carts",
   "requestMethod": "POST",
   "requestPath": "/carts/9FvEebEBWTQw_qOlacHYCJTHkd-KQiJs/items",
   "occurrences": 1
  },
  {
   "clusterName": "api-security-test5",
   "serviceName": "user",
   "requestMethod": "GET",
   "requestPath": "/customers/9FvEebEBWTQw_qOlacHYCJTHkd-KQiJs/cards",
   "occurrences": 1
  },
  {
   "clusterName": "api-security-test5",
   "serviceName": "catalogue",
   "requestMethod": "GET",
   "requestPath": "/catalogue",
   "occurrences": 1
  },
  {
   "clusterName": "api-security-test5",
   "serviceName": "catalogue",
   "requestMethod": "GET",
   "requestPath": "/catalogue",
   "occurrences": 1
  },
  {
   "clusterName": "api-security-test5",
   "serviceName": "catalogue",
   "requestMethod": "GET",
   "requestPath": "/catalogue/{param1}",
   "occurrences": 1
  },
  {
   "clusterName": "api-security-test5",
   "serviceName": "user",
   "requestMethod": "GET",
   "requestPath": "/customers/9FvEebEBWTQw_qOlacHYCJTHkd-KQiJs/addresses",
   "occurrences": 1
  },
  {
   "clusterName": "Test-Api-Security",
   "serviceName": "archive.ubuntu.com",
   "requestMethod": "GET",
   "requestPath": "/ubuntu/dists/noble/restricted/binary-amd64/by-hash/SHA256/{param1}",
   "occurrences": 1
  },
  {
   "clusterName": "Test-Api-Security",
   "serviceName": "archive.ubuntu.com",
   "requestMethod": "GET",
   "requestPath": "/ubuntu/dists/noble-updates/main/binary-amd64/by-hash/SHA256/{param1}",
   "occurrences": 1
  },
  {
   "clusterName": "Test-Api-Security",
   "serviceName": "archive.ubuntu.com",
   "requestMethod": "GET",
   "requestPath": "/ubuntu/dists/noble-updates/multiverse/binary-amd64/by-hash/SHA256/{param1}",
   "occurrences": 1
  },
  {
   "clusterName": "Test-Api-Security",
   "serviceName": "archive.ubuntu.com",
   "requestMethod": "GET",
   "requestPath": "/ubuntu/dists/noble/universe/binary-amd64/by-hash/SHA256/{param1}",
   "occurrences": 1
  },
  {
   "clusterName": "Test-Api-Security",
   "serviceName": "archive.ubuntu.com",
   "requestMethod": "GET",
   "requestPath": "/ubuntu/dists/noble/multiverse/binary-amd64/by-hash/SHA256/{param1}",
   "occurrences": 1
  },
  {
   "clusterName": "api-security-test5",
   "serviceName": "catalogue",
   "requestMethod": "GET",
   "requestPath": "/catalogue/size",
   "occurrences": 1
  },
  {
   "clusterName": "api-security-test5",
   "serviceName": "catalogue",
   "requestMethod": "GET",
   "requestPath": "/catalogue",
   "occurrences": 1
  },
  {
   "clusterName": "api-security-test5",
   "serviceName": "carts",
   "requestMethod": "GET",
   "requestPath": "/carts/9FvEebEBWTQw_qOlacHYCJTHkd-KQiJs/items",
   "occurrences": 4
  },
  {
   "clusterName": "Test-Api-Security",
   "serviceName": "archive.ubuntu.com",
   "requestMethod": "GET",
   "requestPath": "/ubuntu/dists/noble-backports/main/binary-amd64/by-hash/SHA256/{param1}",
   "occurrences": 1
  },
  {
   "clusterName": "Test-Api-Security",
   "serviceName": "archive.ubuntu.com",
   "requestMethod": "GET",
   "requestPath": "/ubuntu/dists/noble-updates/restricted/binary-amd64/by-hash/SHA256/{param1}",
   "occurrences": 1
  },
  {
   "clusterName": "Test-Api-Security",
   "serviceName": "archive.ubuntu.com",
   "requestMethod": "GET",
   "requestPath": "/ubuntu/dists/noble-updates/universe/binary-amd64/by-hash/SHA256/{param1}",
   "occurrences": 1
  },
  {
   "clusterName": "api-security-test5",
   "serviceName": "catalogue",
   "requestMethod": "GET",
   "requestPath": "/tags",
   "occurrences": 1
  },
  {
   "clusterName": "api-security-test5",
   "serviceName": "catalogue",
   "requestMethod": "GET",
   "requestPath": "/catalogue/size",
   "occurrences": 1
  },
  {
   "clusterName": "api-security-test5",
   "serviceName": "catalogue",
   "requestMethod": "GET",
   "requestPath": "/catalogue/size",
   "occurrences": 1
  },
  {
   "clusterName": "api-security-test5",
   "serviceName": "catalogue",
   "requestMethod": "GET",
   "requestPath": "/catalogue",
   "occurrences": 1
  }
 ],
 "orphanApis": [
  {
   "requestMethod": "GET",
   "requestPath": "/"
  },
  {
   "requestMethod": "GET",
   "requestPath": "/v2"
  }
 ]
}
```
